### PR TITLE
BFGS fitting with eta calculation embedded

### DIFF
--- a/de/impute.py
+++ b/de/impute.py
@@ -24,7 +24,7 @@ def impute(data, linear=False):
     missing = np.isnan(data)
     data = np.nan_to_num(data)
 
-    for _ in range(100):
+    for _ in range(10):
         U = np.copy(data)
         np.fill_diagonal(U, 0.0)
 

--- a/de/tests/test_factorization.py
+++ b/de/tests/test_factorization.py
@@ -34,7 +34,7 @@ def test_factorizeBlank(level):
 def test_cellLines():
     """ To test and confirm most genes are overlapping between cell lines. """
     cellLine1 = 'A375'
-    cellLine2 = 'PC3'
+    cellLine2 = 'A549'
     _, annotation1 = importLINCS(cellLine1)
     _, annotation2 = importLINCS(cellLine2)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ scikit-learn==1.0
 NetworkX==2.6.3
 graphviz==0.17
 tqdm
+jax
+jaxlib


### PR DESCRIPTION
I considerably reorganized the fitting process. This may negate the need for a custom derivative—it would be more difficult to calculate with the eta calculation inside of the objective function, and removing the outer EM loop has sped things up quite a bit. I'm curious how this does in merged vs. separated fitting. Note that it might take many more iterations (e.g., 5000) to finish fitting.