### PR TITLE
Gradient always 0

### DIFF
--- a/de/factorization.py
+++ b/de/factorization.py
@@ -181,11 +181,8 @@ def mergedFitting(cellLine1, cellLine2):
 
     return factorizeEstimate(shared_data)
 
-
 def grad(w, D, eta, alpha):
-    """Calculate gradient of the cost w.r.t. w. """
     U = D.copy()
     np.fill_diagonal(U, 0.0)
     expR = expit(w @ U)
-    EEU = 2 * eta[:, np.newaxis] * expR * (np.ones(U.shape) - expR)
-    return EEU @ expR.T - alpha * EEU @ D.T
+    return 2 * (eta[:, np.newaxis] * expR - alpha * D) * (eta[:, np.newaxis] * expR * (np.ones(U.shape) - expR)) @ U.T

--- a/de/factorization.py
+++ b/de/factorization.py
@@ -181,7 +181,9 @@ def mergedFitting(cellLine1, cellLine2):
 
     return factorizeEstimate(shared_data)
 
+
 def grad(w, D, eta, alpha):
+    """ Calculate gradient of the cost w.r.t. w. """
     U = D.copy()
     np.fill_diagonal(U, 0.0)
     expR = expit(w @ U)

--- a/de/tests/test_factorization.py
+++ b/de/tests/test_factorization.py
@@ -98,4 +98,4 @@ def test_gradient():
     cost2 = approx_derivative(cost_flat, w.flatten(), method="3-point") # python's grad
     assert np.linalg.norm(cost1) > 0.0
     assert np.linalg.norm(cost2) > 0.0
-    np.testing.assert_allclose(cost1.flatten(), cost2)
+    np.testing.assert_allclose(cost1.flatten(), cost2, rtol=0.01)

--- a/de/tests/test_factorization.py
+++ b/de/tests/test_factorization.py
@@ -5,8 +5,7 @@ import pytest
 import numpy as np
 from numpy import ma
 from scipy.optimize import approx_fprime
-from scipy.special import expit
-from ..factorization import factorizeEstimate, alpha, commonGenes, mergedFitting, grad, costF
+from ..factorization import factorizeEstimate, alpha, commonGenes, mergedFitting, grad, costF, calcEta
 from ..impute import impute, split_data
 from ..importData import ImportMelanoma, importLINCS
 
@@ -87,8 +86,8 @@ def test_crossval_Melanoma():
 def test_gradient():
     """Test whether the gradient of the cost is correctly calculated w.r.t. w """
     data = ImportMelanoma()
-    w = np.random.random((data.shape[0], data.shape[0]))
-    eta = np.random.random(data.shape[0])
+    w = np.zeros((data.shape[0], data.shape[0]))
+    eta = calcEta(data, w, alpha)
 
     # Cost for flattened matrices. This is just to be able to use the python's grad calculator.
     def cost_flat(wIn):

--- a/de/tests/test_factorization.py
+++ b/de/tests/test_factorization.py
@@ -98,4 +98,4 @@ def test_gradient():
     cost2 = approx_derivative(cost_flat, w.flatten(), method="3-point") # python's grad
     assert np.linalg.norm(cost1) > 0.0
     assert np.linalg.norm(cost2) > 0.0
-    np.testing.assert_allclose(cost1.flatten(), cost2, rtol=0.01)
+    np.testing.assert_allclose(cost1.flatten()[0:1000], cost2[0:1000], rtol=0.001)

--- a/de/tests/test_factorization.py
+++ b/de/tests/test_factorization.py
@@ -86,15 +86,17 @@ def test_crossval_Melanoma():
 
 def test_gradient():
     """Test whether the gradient of the cost is correctly calculated w.r.t. w """
-    data = 20*np.random.random((20, 21))
-    w = 20*np.random.random((20, 20))
-    eta = [np.random.random(20)]
+    data = ImportMelanoma()
+    w = np.random.random((data.shape[0], data.shape[0]))
+    eta = np.random.random(data.shape[0])
 
     # Cost for flattened matrices. This is just to be able to use the python's grad calculator.
     def cost_flat(wIn):
         wIn = wIn.reshape((data.shape[0], data.shape[0]))
-        return costF([data], wIn, [eta[0]], alpha)
+        return costF([data], wIn, [eta], alpha)
 
-    cost1 = grad(w, data, eta[0], alpha) # handwritten gradient of cost w.r.t. w
+    cost1 = grad(w, data, eta, alpha) # handwritten gradient of cost w.r.t. w
     cost2 = approx_fprime(w.flatten(), cost_flat, 1e-10) # python's grad
+    assert np.linalg.norm(cost1) > 0.0
+    assert np.linalg.norm(cost2) > 0.0
     np.testing.assert_allclose(cost1.flatten(), cost2)

--- a/de/tests/test_factorization.py
+++ b/de/tests/test_factorization.py
@@ -4,7 +4,7 @@ Test the factorization model.
 import pytest
 import numpy as np
 from numpy import ma
-from scipy.optimize import approx_fprime
+from scipy.optimize._numdiff import approx_derivative
 from ..factorization import factorizeEstimate, alpha, commonGenes, mergedFitting, grad, costF, calcEta
 from ..impute import impute, split_data
 from ..importData import ImportMelanoma, importLINCS
@@ -95,7 +95,7 @@ def test_gradient():
         return costF([data], wIn, [eta], alpha)
 
     cost1 = grad(w, data, eta, alpha) # handwritten gradient of cost w.r.t. w
-    cost2 = approx_fprime(w.flatten(), cost_flat, 1e-10) # python's grad
+    cost2 = approx_derivative(cost_flat, w.flatten(), method="3-point") # python's grad
     assert np.linalg.norm(cost1) > 0.0
     assert np.linalg.norm(cost2) > 0.0
     np.testing.assert_allclose(cost1.flatten(), cost2)

--- a/manuscript/05.methods.md
+++ b/manuscript/05.methods.md
@@ -47,20 +47,17 @@ Conveniently, this approach can also account for various regularization for the 
 
 ### gradient of cost w.r.t. w
 
-$$\frac{d cost}{d\omega} = \frac{d}{d\omega} Tr\Big[((E(\omega)) - \alpha D) ((E(\omega)) - \alpha D)^T \Big]$$
+$$\frac{d cost}{dw} = \frac{d}{dw} \lVert \epsilon \circ E(w) - \alpha D \rVert^2_F$$
 
-where $E(\omega) = \epsilon \frac{1}{1 + e^{-\omega U}}$.
-
-$$\frac{dcost}{d\omega}= \frac{d}{d\omega} Tr\Big[( E(\omega) - \alpha D) (E(\omega)^T - \alpha D^T) \Big]$$
-The two parts in the above expression could be summarized as:
-
-$$=\frac{d}{d\omega} Tr\Big[ E(\omega) E(\omega)^T - \alpha D E(\omega)^T - \alpha E(\omega) D^T \Big]$$
-$$=\frac{d}{d\omega} Tr\Big[ E(\omega) E(\omega)^T \Big] -2 \alpha \frac{d}{d\omega} Tr\Big[ E(\omega) D^T \Big]$$
-$$= Tr\Big[ \frac{d E(\omega)}{d\omega} E(\omega)^T + E(\omega) \frac{d E(\omega)^T}{d\omega} \Big] - 2\alpha Tr\Big[ \frac{d E(\omega)}{d\omega} D^T\Big]$$
-$$2 Tr[\frac{d}{d\omega} E(\omega) E(\omega)^T] - 2 \alpha Tr[\frac{d E(\omega)}{d\omega} D^T]$$
+where $E(w) = \frac{1}{1 + e^{-w U}}$.
 
 considering:
 
-$$\frac{d}{d\omega} E(\omega) = \epsilon \circ E(\omega) \circ (1 - E(\omega))$$
+$$\frac{d}{dw} E(w) = \epsilon \circ E(w) \circ (\bm{1} - E(w)) $$
+
+we have
+
+$$\frac{dcost}{dw}= 2 * (\epsilon \circ E(w) - \alpha D) \circ \epsilon \circ E(w) \circ (\bm{1} - E(w)) * U^T$$
+
 
 


### PR DESCRIPTION
So the random values being used were such that rounding errors were causing both the numerical differencing and hand-calculated gradients to be all zeros. I resolved this using real data, and now the gradients do not match. Can you take a second look at this?